### PR TITLE
rumble-aetna: lean on aetna affordances + wire bundled Mumble glyphs + dump_bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ chat_logs/
 client_configs/
 reference/
 .claude/worktrees/
+
+# Generated artifacts from `cargo run -p rumble-aetna --bin dump_bundles`
+crates/rumble-aetna/out/

--- a/crates/rumble-aetna/assets/icons/README.md
+++ b/crates/rumble-aetna/assets/icons/README.md
@@ -5,36 +5,52 @@ SVGs lifted directly from
 (LGPL-3.0-or-later, same license as Mumble itself; redistributable
 under the GPL-2.0+ in the rumble project).
 
-These are not yet wired into the renderer. Aetna's `icon()` builder
-takes an `IconName` enum, which is closed inside `aetna-core`. To use
-custom SVG icons we need to either:
+## Wiring icons in
 
-1. **Extend the vendored aetna `IconName`.** Add new variants in
-   `vendor/aetna/crates/aetna-core/src/tree/types.rs::IconName`, parse
-   the SVG body into the matching `&[IconStroke]` plus
-   `parse_current_color_svg_asset(...)` `VectorAsset`, and add the
-   variant to `all_icon_names()` / `icon_strokes()` / `icon_path()` in
-   `aetna-core/src/icons.rs`. This is the most straightforward path —
-   every icon now flows through the same `text_color`-tinted pipeline as
-   `IconName::Folder` / `IconName::Users`.
+Aetna's `icon()` builder accepts both built-in `IconName` values and
+app-supplied SVGs through `SvgIcon`. The pattern: parse each SVG once
+into a `LazyLock<SvgIcon>` static, then `icon(MY_GLYPH.clone())` at
+the call site. Cloning is a cheap `Arc` bump, and content-hashing
+inside `aetna-core` dedups the MSDF atlas slot automatically.
 
-2. **Add an open-ended `register_icon(name, svg)` API to aetna.** The
-   internals already cache `VectorAsset`s in a `OnceLock<Vec<...>>` so
-   this is feasible but requires a real change to aetna's public
-   surface.
+```rust
+use std::sync::LazyLock;
+use aetna_core::prelude::*;
 
-Approach (1) is what we'll pursue first if `rumble-aetna` reaches
-enough parity to need them. Until then we use aetna's stock lucide-ish
-vocabulary (`Folder`, `Users`, `Activity`, `AlertCircle`, …).
+static SVG_TALKING_ON: LazyLock<SvgIcon> = LazyLock::new(|| {
+    SvgIcon::parse(include_str!("../assets/icons/talking_on.svg"))
+        .expect("talking_on.svg parses")
+});
 
-## Index
+icon(SVG_TALKING_ON.clone()).icon_size(12.0)
+```
 
-- `talking_on.svg` / `talking_off.svg` — speaking indicators (replace stock `Activity`).
+The Mumble theme bakes its semantic colors into each SVG (red for
+self-mute, blue for talking, etc.), so we use `SvgIcon::parse` rather
+than `SvgIcon::parse_current_color` — the authored fill *is* the
+visual signal, and `.text_color(...)` would override it. Reach for
+`parse_current_color` only on monochrome lucide-style glyphs that
+need theme tinting.
+
+## What's wired today
+
+User-state mic glyphs in `app.rs::push_room_subtree`:
+
+| State | SVG |
+|---|---|
+| Talking | `talking_on.svg` |
+| Idle | `talking_off.svg` |
+| Self-muted | `muted_self.svg` |
+| Server-muted | `muted_server.svg` |
+
+## Index — wire as needed
+
+- `talking_on.svg` / `talking_off.svg` — speaking indicators (wired).
 - `muted_self.svg` / `muted_pushtomute.svg` / `muted_suppressed.svg` — mic-off variants.
-- `muted_server.svg` — server-imposed mute (red lock icon).
+- `muted_server.svg` — server-imposed mute (wired).
 - `muted_local.svg` — locally muted other user (yellow bell).
 - `deafened_self.svg` / `deafened_server.svg` / `self_undeafened.svg` — deafen states.
-- `channel.svg` / `channel_active.svg` — room/channel folder glyphs.
+- `channel.svg` / `channel_active.svg` — currently empty `<svg>` placeholders in the upstream theme. Use `IconName::Folder` for the room glyph until rumble ships its own.
 - `authenticated.svg` — registered-user indicator.
 - `priority_speaker.svg` — priority-speaker badge.
 - `filter_on.svg` / `filter_off.svg` — chat/user-list filter toggle.

--- a/crates/rumble-aetna/src/app.rs
+++ b/crates/rumble-aetna/src/app.rs
@@ -408,12 +408,17 @@ fn top_toolbar(state: &State) -> El {
 fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection, width: f32) -> El {
     let messages: Vec<El> = if state.chat_messages.is_empty() {
         vec![
+            // wrap_text() so the longer placeholder fits inside narrow
+            // sidebar widths (~256 px = SIDEBAR_WIDTH minus padding) —
+            // without it, "Connect to a server to start chatting"
+            // overflows by a few pixels on the default sidebar.
             text(if matches!(state.connection, ConnectionState::Connected { .. }) {
                 "No messages yet"
             } else {
                 "Connect to a server to start chatting"
             })
-            .muted(),
+            .muted()
+            .wrap_text(),
         ]
     } else {
         state.chat_messages.iter().map(render_chat_line).collect()
@@ -643,7 +648,11 @@ fn cert_modal(cert_info: &PendingCertificate) -> El {
             .gap(tokens::SPACE_SM)
             .align(Align::Center),
             text("Fingerprint (SHA-256)").muted(),
-            mono(cert_info.fingerprint_hex()).font_size(tokens::FONT_SM),
+            // SHA-256 hex with colon separators is 79 chars wide —
+            // wrap_text() so it flows across two lines instead of
+            // overflowing the modal. The user needs to read the full
+            // hash, so .ellipsis() would be wrong here.
+            mono(cert_info.fingerprint_hex()).font_size(tokens::FONT_SM).wrap_text(),
             paragraph(
                 "Only accept if this fingerprint matches what the server administrator gave you. Once accepted, the \
                  certificate is saved for future connections.",

--- a/crates/rumble-aetna/src/app.rs
+++ b/crates/rumble-aetna/src/app.rs
@@ -3,6 +3,8 @@
 //! Owns local UI state (connect form fields, modal flags, selected
 //! room) and projects `(state, ui_state) -> El` on every frame.
 
+use std::sync::LazyLock;
+
 use aetna_core::prelude::*;
 
 use rumble_desktop_shell::{AcceptedCertificate, SettingsStore};
@@ -12,6 +14,31 @@ use crate::{
     backend::UiBackend,
     theme::{self as palette},
 };
+
+// ---- Bundled Mumble SVG glyphs ----
+//
+// Parsed once at first use (Arc-bumped on every `icon(...)` call) and
+// shared across frames. We use `SvgIcon::parse` (not
+// `parse_current_color`) because the Mumble theme bakes its semantic
+// colors into the SVG paint — red for self-mute, blue for talking, etc.
+// — and those colors are exactly the visual signal we want to keep.
+
+static SVG_TALKING_ON: LazyLock<SvgIcon> = LazyLock::new(|| {
+    SvgIcon::parse(include_str!("../assets/icons/talking_on.svg"))
+        .expect("talking_on.svg parses")
+});
+static SVG_TALKING_OFF: LazyLock<SvgIcon> = LazyLock::new(|| {
+    SvgIcon::parse(include_str!("../assets/icons/talking_off.svg"))
+        .expect("talking_off.svg parses")
+});
+static SVG_MUTED_SELF: LazyLock<SvgIcon> = LazyLock::new(|| {
+    SvgIcon::parse(include_str!("../assets/icons/muted_self.svg"))
+        .expect("muted_self.svg parses")
+});
+static SVG_MUTED_SERVER: LazyLock<SvgIcon> = LazyLock::new(|| {
+    SvgIcon::parse(include_str!("../assets/icons/muted_server.svg"))
+        .expect("muted_server.svg parses")
+});
 
 /// Local-only first-run identity wrapper.
 ///
@@ -64,6 +91,14 @@ pub struct RumbleApp<B: UiBackend = crate::backend::NativeUiBackend> {
 
     chat_input: String,
     chat_sel: TextSelection,
+
+    /// Chat sidebar width in logical pixels — adjusted by dragging
+    /// the divider on its right edge. Initialized from
+    /// [`tokens::SIDEBAR_WIDTH`] (the conventional ~256px starting
+    /// point) and clamped to [`tokens::SIDEBAR_WIDTH_MIN`] /
+    /// `_MAX` by the resize handler.
+    chat_sidebar_w: f32,
+    chat_sidebar_drag: ResizeDrag,
 }
 
 impl<B: UiBackend> RumbleApp<B> {
@@ -79,6 +114,8 @@ impl<B: UiBackend> RumbleApp<B> {
             username_sel: TextSelection::default(),
             chat_input: String::new(),
             chat_sel: TextSelection::default(),
+            chat_sidebar_w: tokens::SIDEBAR_WIDTH,
+            chat_sidebar_drag: ResizeDrag::default(),
         }
     }
 }
@@ -96,17 +133,15 @@ impl<B: UiBackend> App for RumbleApp<B> {
         let main = column([
             top_toolbar(&state),
             row([
-                chat_sidebar(&state, &self.chat_input, self.chat_sel),
+                chat_sidebar(&state, &self.chat_input, self.chat_sel, self.chat_sidebar_w),
+                resize_handle(Axis::Row).key(CHAT_SIDEBAR_HANDLE),
                 center_area(&state, self.connect_modal_open),
             ])
-            .gap(0.0)
             .width(Size::Fill(1.0))
             .height(Size::Fill(1.0))
             .align(Align::Stretch),
         ])
-        .gap(0.0)
         .fill_size()
-        .fill(tokens::BG_APP)
         .align(Align::Stretch);
 
         let cert_layer = if let ConnectionState::CertificatePending { cert_info } = &state.connection {
@@ -136,6 +171,21 @@ impl<B: UiBackend> App for RumbleApp<B> {
     }
 
     fn on_event(&mut self, event: UiEvent) {
+        // Chat sidebar resize. Routed events return early so the
+        // handle's drag stream doesn't fall through to other matchers.
+        if event.route() == Some(CHAT_SIDEBAR_HANDLE) {
+            resize_handle::apply_event_fixed(
+                &mut self.chat_sidebar_w,
+                &mut self.chat_sidebar_drag,
+                &event,
+                CHAT_SIDEBAR_HANDLE,
+                Axis::Row,
+                tokens::SIDEBAR_WIDTH_MIN,
+                tokens::SIDEBAR_WIDTH_MAX,
+            );
+            return;
+        }
+
         // Connect modal lifecycle.
         if event.is_click_or_activate("connect:open") {
             self.connect_modal_open = true;
@@ -294,20 +344,22 @@ impl<B: UiBackend> RumbleApp<B> {
 
 // ---------- view helpers ----------
 
+const CHAT_SIDEBAR_HANDLE: &str = "chat-sidebar:resize";
+
 fn top_toolbar(state: &State) -> El {
     let connected = matches!(state.connection, ConnectionState::Connected { .. });
 
     let status = match &state.connection {
-        ConnectionState::Disconnected => text("● Disconnected").muted(),
+        ConnectionState::Disconnected => badge("Disconnected").muted(),
         ConnectionState::Connecting { server_addr } => {
-            text(format!("● Connecting to {server_addr}...")).text_color(tokens::WARNING)
+            badge(format!("Connecting to {server_addr}…")).warning()
         }
-        ConnectionState::Connected { server_name, .. } => text(format!("● {server_name}")).text_color(tokens::SUCCESS),
+        ConnectionState::Connected { server_name, .. } => badge(server_name.clone()).success(),
         ConnectionState::ConnectionLost { error } => {
-            text(format!("● Connection lost: {error}")).text_color(tokens::DESTRUCTIVE)
+            badge(format!("Connection lost: {error}")).destructive()
         }
         ConnectionState::CertificatePending { cert_info } => {
-            text(format!("⚠ Cert pending: {}", cert_info.server_name)).text_color(tokens::WARNING)
+            badge(format!("Cert pending: {}", cert_info.server_name)).warning()
         }
     };
 
@@ -319,14 +371,7 @@ fn top_toolbar(state: &State) -> El {
         VoiceMode::Continuous => "Continuous",
     };
 
-    let mut children: Vec<El> = vec![
-        text("Rumble")
-            .font_size(tokens::FONT_LG)
-            .font_weight(FontWeight::Bold)
-            .text_color(tokens::TEXT_FOREGROUND),
-        status,
-        spacer(),
-    ];
+    let mut children: Vec<El> = vec![text("Rumble").title(), status, spacer()];
 
     if connected {
         let mute_btn = button(mute_label).key("toolbar:mute");
@@ -360,7 +405,7 @@ fn top_toolbar(state: &State) -> El {
         .align(Align::Center)
 }
 
-fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection) -> El {
+fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection, width: f32) -> El {
     let messages: Vec<El> = if state.chat_messages.is_empty() {
         vec![
             text(if matches!(state.connection, ConnectionState::Connected { .. }) {
@@ -375,10 +420,7 @@ fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection) -> El 
     };
 
     column([
-        text("Chat")
-            .font_size(tokens::FONT_LG)
-            .font_weight(FontWeight::Semibold)
-            .padding(Sides::xy(tokens::SPACE_MD, tokens::SPACE_SM)),
+        text("Chat").title().padding(Sides::xy(tokens::SPACE_MD, tokens::SPACE_SM)),
         divider(),
         scroll(messages)
             .padding(Sides::all(tokens::SPACE_SM))
@@ -386,12 +428,12 @@ fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection) -> El 
             .width(Size::Fill(1.0))
             .height(Size::Fill(1.0)),
         divider(),
-        row([text_input(chat_input, chat_sel).key("chat:input")])
+        text_input(chat_input, chat_sel)
+            .key("chat:input")
             .padding(Sides::all(tokens::SPACE_SM))
             .width(Size::Fill(1.0)),
     ])
-    .gap(0.0)
-    .width(Size::Fixed(320.0))
+    .width(Size::Fixed(width))
     .height(Size::Fill(1.0))
     .fill(tokens::BG_CARD)
 }
@@ -470,10 +512,7 @@ fn rooms_view(state: &State) -> El {
     }
 
     column([
-        text("Rooms")
-            .font_size(tokens::FONT_LG)
-            .font_weight(FontWeight::Semibold)
-            .padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM)),
+        text("Rooms").title().padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM)),
         divider(),
         scroll(entries)
             .padding(Sides::all(tokens::SPACE_MD))
@@ -481,7 +520,6 @@ fn rooms_view(state: &State) -> El {
             .width(Size::Fill(1.0))
             .height(Size::Fill(1.0)),
     ])
-    .gap(0.0)
     .width(Size::Fill(1.0))
     .height(Size::Fill(1.0))
 }
@@ -543,14 +581,17 @@ fn push_room_subtree(state: &State, room_id: uuid::Uuid, depth: usize, out: &mut
             .is_some_and(|id| id == room_id)
     }) {
         let user_id = user.user_id.as_ref().map(|u| u.value).unwrap_or(0);
-        let (mic_color, mic_icon) = if user.server_muted {
-            (palette::MUTED_SERVER, IconName::AlertCircle)
+        // Mic-state glyph picks up its color from the bundled Mumble
+        // SVG itself (red self-mute, blue server-mute, blue talking,
+        // green idle), so no `.text_color(...)` override here.
+        let mic_icon: SvgIcon = if user.server_muted {
+            SVG_MUTED_SERVER.clone()
         } else if user.is_muted {
-            (palette::MUTED_SELF, IconName::AlertCircle)
+            SVG_MUTED_SELF.clone()
         } else if state.audio.talking_users.contains(&user_id) {
-            (palette::TALKING, IconName::Activity)
+            SVG_TALKING_ON.clone()
         } else {
-            (palette::DIM, IconName::Activity)
+            SVG_TALKING_OFF.clone()
         };
 
         let mut name_el = text(user.username.clone()).font_size(tokens::FONT_SM);
@@ -561,7 +602,7 @@ fn push_room_subtree(state: &State, room_id: uuid::Uuid, depth: usize, out: &mut
         out.push(
             row([
                 spacer().width(Size::Fixed(indent + tokens::SPACE_LG)),
-                icon(mic_icon).text_color(mic_color).icon_size(12.0),
+                icon(mic_icon).icon_size(12.0),
                 name_el,
             ])
             .gap(tokens::SPACE_SM)

--- a/crates/rumble-aetna/src/app.rs
+++ b/crates/rumble-aetna/src/app.rs
@@ -423,14 +423,14 @@ fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection, width:
         text("Chat").title().padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM)),
         divider(),
         scroll(messages)
-            .padding(Sides::all(tokens::SPACE_SM))
+            .padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM))
             .gap(tokens::SPACE_XS)
             .width(Size::Fill(1.0))
             .height(Size::Fill(1.0)),
         divider(),
         text_input(chat_input, chat_sel)
             .key("chat:input")
-            .padding(Sides::all(tokens::SPACE_SM))
+            .padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM))
             .width(Size::Fill(1.0)),
     ])
     .width(Size::Fixed(width))
@@ -515,7 +515,7 @@ fn rooms_view(state: &State) -> El {
         text("Rooms").title().padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM)),
         divider(),
         scroll(entries)
-            .padding(Sides::all(tokens::SPACE_MD))
+            .padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_MD))
             .gap(tokens::SPACE_XS)
             .width(Size::Fill(1.0))
             .height(Size::Fill(1.0)),

--- a/crates/rumble-aetna/src/app.rs
+++ b/crates/rumble-aetna/src/app.rs
@@ -420,7 +420,7 @@ fn chat_sidebar(state: &State, chat_input: &str, chat_sel: TextSelection, width:
     };
 
     column([
-        text("Chat").title().padding(Sides::xy(tokens::SPACE_MD, tokens::SPACE_SM)),
+        text("Chat").title().padding(Sides::xy(tokens::SPACE_LG, tokens::SPACE_SM)),
         divider(),
         scroll(messages)
             .padding(Sides::all(tokens::SPACE_SM))

--- a/crates/rumble-aetna/src/bin/dump_bundles.rs
+++ b/crates/rumble-aetna/src/bin/dump_bundles.rs
@@ -1,0 +1,299 @@
+//! Dump aetna bundle artifacts (svg + tree + draw_ops + lint + manifest)
+//! for every canonical UI scene of `rumble-aetna`.
+//!
+//! Run:
+//!   cargo run -p rumble-aetna --bin dump_bundles
+//!   cargo run -p rumble-aetna --bin dump_bundles -- connected cert_pending
+//!
+//! Output: `crates/rumble-aetna/out/rumble_<scene>.{svg,tree.txt,draw_ops.txt,lint.txt,shader_manifest.txt}`.
+//!
+//! Mirrors the `aetna-volume::render_artifacts` shape: a small
+//! `MockBackend` that returns a canned `State`, a `Scene` enum that
+//! enumerates the views worth snapshotting, and the same four-line
+//! `render_bundle` + `write_bundle` core that aetna-core ships in the
+//! prelude. No GPU is involved — the SVG fallback renders the same
+//! draw-op stream the wgpu Runner would, so layout regressions show
+//! up faithfully without spinning up a window or device.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use aetna_core::prelude::*;
+
+use rumble_aetna::{RumbleApp, app::Identity, backend::UiBackend};
+use rumble_desktop_shell::SettingsStore;
+use rumble_protocol::{
+    AudioState, ChatMessage, ChatMessageKind, Command, ConnectionState, PendingCertificate,
+    State, Uuid, VoiceMode,
+    proto::{RoomInfo, User, UserId},
+    room_id_from_uuid,
+};
+
+// ---------------------------------------------------------------------
+// Mock backend
+// ---------------------------------------------------------------------
+
+/// Returns a canned `State` to the renderer and discards every command.
+/// The fixture only exercises the read half of [`UiBackend`]; commands
+/// would be no-ops here even if we did record them, since there's no
+/// backend to apply them.
+struct MockBackend {
+    state: State,
+}
+
+impl UiBackend for MockBackend {
+    fn state(&self) -> State {
+        self.state.clone()
+    }
+    fn send(&self, _command: Command) {}
+}
+
+// ---------------------------------------------------------------------
+// Scene catalog
+// ---------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+enum Scene {
+    /// Idle disconnected state — toolbar shows the muted "Disconnected"
+    /// pill and the welcome panel.
+    Disconnected,
+    /// Connect form open over the disconnected backdrop.
+    ConnectModalOpen,
+    /// Connection in progress.
+    Connecting,
+    /// Live session: rooms, users, chat — exercises the full shell.
+    Connected,
+    /// Connection lost with an error message in the toolbar.
+    ConnectionLost,
+    /// Cert acceptance modal up over the disconnected backdrop.
+    CertPending,
+}
+
+impl Scene {
+    const ALL: &'static [Scene] = &[
+        Scene::Disconnected,
+        Scene::ConnectModalOpen,
+        Scene::Connecting,
+        Scene::Connected,
+        Scene::ConnectionLost,
+        Scene::CertPending,
+    ];
+
+    fn slug(self) -> &'static str {
+        match self {
+            Scene::Disconnected => "disconnected",
+            Scene::ConnectModalOpen => "connect_modal_open",
+            Scene::Connecting => "connecting",
+            Scene::Connected => "connected",
+            Scene::ConnectionLost => "connection_lost",
+            Scene::CertPending => "cert_pending",
+        }
+    }
+
+    fn build_state(self) -> State {
+        match self {
+            Scene::Disconnected => State::default(),
+            Scene::ConnectModalOpen => State::default(),
+            Scene::Connecting => State {
+                connection: ConnectionState::Connecting {
+                    server_addr: "rumble.example:5000".into(),
+                },
+                ..State::default()
+            },
+            Scene::Connected => connected_state(),
+            Scene::ConnectionLost => State {
+                connection: ConnectionState::ConnectionLost {
+                    error: "stream closed by peer".into(),
+                },
+                ..State::default()
+            },
+            Scene::CertPending => State {
+                connection: ConnectionState::CertificatePending {
+                    cert_info: demo_pending_cert(),
+                },
+                ..State::default()
+            },
+        }
+    }
+
+    /// Drive any local UI state the scene needs by injecting synthetic
+    /// events through the real `App::on_event` path. This means the
+    /// rendered scene is exactly what the user would see after
+    /// performing the same interaction — there's no "fixture-only"
+    /// shortcut that the production code can drift away from.
+    fn drive_setup(self, app: &mut RumbleApp<MockBackend>) {
+        match self {
+            Scene::ConnectModalOpen => {
+                app.on_event(UiEvent::synthetic_click("connect:open"));
+            }
+            _ => {}
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Canned data for the "Connected" scene
+// ---------------------------------------------------------------------
+
+const ROOM_LOBBY: u128 = 0x1111_1111_1111_1111_1111_1111_1111_1111;
+const ROOM_WORK: u128 = 0x2222_2222_2222_2222_2222_2222_2222_2222;
+
+fn make_room(uuid: u128, name: &str) -> RoomInfo {
+    RoomInfo {
+        id: Some(room_id_from_uuid(Uuid::from_u128(uuid))),
+        name: name.into(),
+        parent_id: None,
+        description: None,
+        inherit_acl: false,
+        acls: Vec::new(),
+        effective_permissions: 0,
+    }
+}
+
+fn make_user(id: u64, name: &str, room: u128, mut tweak: impl FnMut(&mut User)) -> User {
+    let mut u = User {
+        user_id: Some(UserId { value: id }),
+        username: name.into(),
+        current_room: Some(room_id_from_uuid(Uuid::from_u128(room))),
+        is_muted: false,
+        is_deafened: false,
+        server_muted: false,
+        is_elevated: false,
+        groups: Vec::new(),
+    };
+    tweak(&mut u);
+    u
+}
+
+fn make_chat(id: u8, sender: &str, text: &str, kind: ChatMessageKind) -> ChatMessage {
+    let mut bytes = [0u8; 16];
+    bytes[15] = id;
+    ChatMessage {
+        id: bytes,
+        sender: sender.into(),
+        text: text.into(),
+        timestamp: SystemTime::UNIX_EPOCH,
+        is_local: false,
+        kind,
+        attachment: None,
+    }
+}
+
+fn connected_state() -> State {
+    let mut audio = AudioState::default();
+    audio.voice_mode = VoiceMode::Continuous;
+    // Bob is talking; Charlie is self-muted.
+    audio.talking_users.insert(2);
+
+    let mut state = State {
+        connection: ConnectionState::Connected {
+            server_name: "rumble.example".into(),
+            user_id: 1,
+        },
+        rooms: vec![make_room(ROOM_LOBBY, "Lobby"), make_room(ROOM_WORK, "Work")],
+        users: vec![
+            make_user(1, "alice", ROOM_LOBBY, |_| {}),
+            make_user(2, "bob", ROOM_WORK, |_| {}),
+            make_user(3, "charlie", ROOM_LOBBY, |u| u.is_muted = true),
+            make_user(4, "diana", ROOM_WORK, |u| u.server_muted = true),
+        ],
+        my_user_id: Some(1),
+        my_room_id: Some(Uuid::from_u128(ROOM_LOBBY)),
+        audio,
+        chat_messages: vec![
+            make_chat(1, "alice", "morning everyone", ChatMessageKind::Room),
+            make_chat(2, "bob", "did the deploy go through?", ChatMessageKind::Room),
+            make_chat(
+                3,
+                "charlie",
+                "(announcement) maintenance window 14:00 UTC",
+                ChatMessageKind::Tree,
+            ),
+        ],
+        ..State::default()
+    };
+    state.rebuild_room_tree();
+    state
+}
+
+fn demo_pending_cert() -> PendingCertificate {
+    let no_op_signer: rumble_client::SigningCallback =
+        Arc::new(|_payload: &[u8]| Err("fixture identity is not signing".to_string()));
+    PendingCertificate {
+        certificate_der: vec![0u8; 32],
+        fingerprint: [
+            0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC,
+            0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78,
+            0x9A, 0xBC, 0xDE, 0xF0,
+        ],
+        server_name: "rumble.example".into(),
+        server_addr: "rumble.example:5000".into(),
+        username: "alice".into(),
+        password: None,
+        public_key: [0u8; 32],
+        signer: no_op_signer,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Match the real app's window viewport so layout matches what users see.
+    let viewport = Rect::new(0.0, 0.0, 1280.0, 800.0);
+    let out_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("out");
+
+    // Identity / SettingsStore both want a config dir to write to.
+    // Fixtures don't actually mutate either, but the constructors
+    // create files, so use a process-local scratch dir.
+    let scratch = std::env::temp_dir().join("rumble_aetna_dump_bundles");
+    std::fs::create_dir_all(&scratch)?;
+
+    let requested: Vec<Scene> = std::env::args()
+        .skip(1)
+        .map(|raw| parse_scene(&raw).unwrap_or_else(|| panic!("unknown scene `{raw}`")))
+        .collect();
+    let scenes: Vec<Scene> = if requested.is_empty() {
+        Scene::ALL.to_vec()
+    } else {
+        requested
+    };
+
+    for scene in scenes {
+        let backend = MockBackend {
+            state: scene.build_state(),
+        };
+        let identity = Identity::load(scratch.clone())?;
+        let settings = SettingsStore::load_from_path(Some(scratch.join("settings.json")));
+        let mut app = RumbleApp::new(backend, identity, settings);
+        scene.drive_setup(&mut app);
+
+        let mut tree = app.build();
+        let bundle = render_bundle(&mut tree, viewport, Some("crates/rumble-aetna/src"));
+
+        let basename = format!("rumble_{}", scene.slug());
+        let written = write_bundle(&bundle, &out_dir, &basename)?;
+        for path in &written {
+            println!("wrote {}", path.display());
+        }
+
+        if !bundle.lint.findings.is_empty() {
+            eprintln!(
+                "\n{basename} lint findings ({}):",
+                bundle.lint.findings.len()
+            );
+            eprint!("{}", bundle.lint.text());
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_scene(raw: &str) -> Option<Scene> {
+    Scene::ALL
+        .iter()
+        .copied()
+        .find(|s| s.slug().eq_ignore_ascii_case(raw))
+}


### PR DESCRIPTION
## Summary

Polish pass on the in-progress `rumble-aetna` port that compounded into a few real wins — and a small handful of upstream aetna fixes that the work surfaced. Driven by an idiomatic-aetna case study Christian and I walked through earlier today.

**Features**

- **Resizable chat sidebar.** Width is now app state, initialized to `tokens::SIDEBAR_WIDTH` (256 px, the convention) and clamped to `SIDEBAR_WIDTH_MIN..=SIDEBAR_WIDTH_MAX`. A `resize_handle` between the sidebar and the main area lets the user drag; arrow keys nudge the focused handle by 8 px (PageUp/Dn 40 px, Home/End to the bounds).
- **Bundled Mumble glyphs are wired in.** `talking_on.svg`, `talking_off.svg`, `muted_self.svg`, `muted_server.svg` are now loaded via `SvgIcon::parse` + `LazyLock` statics and shown on user rows, replacing the generic `IconName::Activity` / `IconName::AlertCircle` placeholders. We use `parse` (not `parse_current_color`) so Mumble's authored fill colors — red self-mute, blue talking, green idle — survive as the visual signal; no `.text_color(...)` override needed at the call site.
- **`dump_bundles` bin.** Same shape as `aetna-volume::render_artifacts`: a `MockBackend` returning a canned `State`, six canonical scenes, four-line `render_bundle` + `write_bundle` core. Output goes to `crates/rumble-aetna/out/` (gitignored). All six scenes lint clean. Runs CPU-only — no GPU, no window, fast enough for save-on-iter feedback.

**Mechanical cleanups (idiomatic-aetna pass)**

- Headings (`Rumble`, `Chat`, `Rooms`) now use `.title()` instead of `.font_size(FONT_LG).font_weight(Semibold|Bold).text_color(...)`.
- Connection status renders as `badge(...).success() / .warning() / .destructive() / .muted()` instead of `text("● Connected").text_color(SUCCESS)`.
- Drop redundant `.gap(0.0)` (the default) and `.fill(tokens::BG_APP)` on the root (the host already paints it).
- `text_input` no longer wrapped in `row([single_child])` for padding — `.padding(...)` goes directly on the input.
- Sidebar header padding aligned across `Chat` / `Rooms` (both at `Sides::xy(SPACE_LG, …)`); body content (scroll viewports, chat composer) bumped to match the title's horizontal padding so the leftmost glyphs line up.

**Lint-driven fixes**

After upstream aetna's lint-marker semantics were inverted to actually scope to this crate's findings, two real overflows appeared and got fixed:

- Sidebar empty-state ("Connect to a server to start chatting") — 3 px overflow on the 256 px sidebar; `.wrap_text()` so it flows across two lines.
- Cert modal SHA-256 fingerprint — 204 px overflow; `.wrap_text()` so the full hash stays visible across two lines instead of getting clipped.

The `assets/icons/README.md` is rewritten to reflect the `SvgIcon::parse` path so the next round of icon work reaches for the right API rather than the obsolete "extend `IconName`" plan it described.

## Dependency note

Requires the vendored `aetna` to include several upstream fixes that landed alongside this work:

- `SvgIcon` / `IntoIconSource` for app-supplied SVG icons
- `tokens::SIDEBAR_WIDTH` / `_MIN` / `_MAX`
- `resize_handle` + `ResizeDrag` + `apply_event_fixed`
- `draw_ops` text/icon padding inset (otherwise `text(...).padding(...)` inflates intrinsic only and produces zero visible padding)
- `overlay_rect` constrains intrinsic measurement to the child's resolved width (otherwise wrap-text inside Fixed-width modals under-measures the modal's Hug height, eating bottom padding)
- Lint marker renamed `library_path_marker` → `app_path_marker`, semantics inverted (the marker now scopes findings *to* the matching path rather than filtering them out — the old idiom of passing your own crate's path silently dropped every user finding)

Vendor aetna at recent `main` (post the lint-marker rename) and `cargo check -p rumble-aetna` should be clean.

`Cargo.lock` is intentionally unchanged — `vendor/` is gitignored locally, so each contributor's lockfile resolves against their own vendor copy.

## Test plan

- [ ] Vendor aetna at recent `main`, `cargo check -p rumble-aetna`
- [ ] `cargo run -p rumble-aetna --bin dump_bundles` — six scenes render under `crates/rumble-aetna/out/`, every `*.lint.txt` reads `no findings`
- [ ] Run the client; connect to a server, confirm the toolbar status pill renders correctly through Disconnected → Connecting → Connected → ConnectionLost transitions
- [ ] Drag the divider between chat sidebar and main pane; confirm it clamps at min/max and the layout reflows live
- [ ] Tab to the divider (focus ring shows), arrow-key it left/right, Tab off — focus should move past, not trap
- [ ] In a room with users, observe talking / muted-self / muted-server icons render in their authored Mumble colors (no manual tinting needed)
- [ ] Trigger a cert acceptance prompt; confirm the SHA-256 fingerprint flows across two lines instead of overflowing the modal, and that the Reject / Trust-and-connect buttons sit comfortably above the modal's bottom edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)